### PR TITLE
Add Icon Component (wrapper) to index template (Implements: #2)

### DIFF
--- a/lib/templates/index.js
+++ b/lib/templates/index.js
@@ -3,3 +3,19 @@
 export {<% _.forEach(components, function(comp, index) { %>
   <%= comp %><% if (index !== components.length - 1) {%>,<% } %><% }); %>
 }
+
+const Icon = ({ name, ...iconProps }) => {
+  const ChosenIcon = exports[name];
+
+  if (!ChosenIcon) {
+    throw new Error(`Cannot find icon '${name}'`);
+  }
+
+  return <ChosenIcon {...iconProps} />;
+};
+
+Icon.propTypes = {
+  name: PropTypes.oneOf(exports.keys())
+};
+
+export default Icon;


### PR DESCRIPTION
I think the better place to put this component is inside `index.js` because we can access `exports` obj. 

Otherwise, we would've to create other file with `import * from './index'`,  that includes `default`, which would be himself (causing a Circular object).