### PR TITLE
Normalize multiple attributes.

### DIFF
--- a/utils/svg.js
+++ b/utils/svg.js
@@ -29,8 +29,8 @@ const normalize = (file) => {
   const $ = removeUnnecessaryAttrs(load(file));
 
   return _.chain($.html())
-    .replace('fill-rule', 'fillRule')
-    .replace('xlink:href', 'xlinkHref')
+    .replace(new RegExp('fill-rule', 'g'), 'fillRule')
+    .replace(new RegExp('xlink:href', 'g'), 'xlinkHref')
     .value();
 };
 


### PR DESCRIPTION
When it found in the file more than an 'fill-rule' or 'xlink:href', it replaced only the first occurrence.